### PR TITLE
feat[PSY-53]: made display name changerable

### DIFF
--- a/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/AccountService.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/AccountService.kt
@@ -40,4 +40,24 @@ class AccountService(
                 ),
         )
     }
+
+    fun updateDisplayName(command: AccountCommand.UpdateDisplayName): AccountResult {
+        val normalizedDisplayName = command.displayName.trim()
+        if (normalizedDisplayName.length !in DISPLAY_NAME_LENGTH_RANGE) {
+            return AccountResult.Failure.InvalidDisplayName
+        }
+
+        val account =
+            accountRepository.findByIdAndDeletedAtIsNull(command.accountId)
+                ?: return AccountResult.Failure.AccountNotFound
+
+        account.updateDisplayName(normalizedDisplayName)
+        return AccountResult.Updated.DisplayName(
+            displayName = normalizedDisplayName,
+        )
+    }
+
+    companion object {
+        private val DISPLAY_NAME_LENGTH_RANGE = 1..40
+    }
 }

--- a/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/dto/AccountCommand.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/dto/AccountCommand.kt
@@ -1,10 +1,17 @@
 package pizza.psycho.sos.identity.account.application.service.dto
 
+import java.util.UUID
+
 sealed interface AccountCommand {
     data class Register(
         val email: String,
         val password: String,
         val firstName: String,
         val lastName: String,
+    ) : AccountCommand
+
+    data class UpdateDisplayName(
+        val accountId: UUID,
+        val displayName: String,
     ) : AccountCommand
 }

--- a/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/dto/AccountResult.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/dto/AccountResult.kt
@@ -5,8 +5,18 @@ sealed interface AccountResult {
         val account: AccountSnapshot,
     ) : AccountResult
 
+    sealed interface Updated : AccountResult {
+        data class DisplayName(
+            val displayName: String,
+        ) : Updated
+    }
+
     sealed interface Failure : AccountResult {
         data object EmailAlreadyRegistered : Failure
+
+        data object InvalidDisplayName : Failure
+
+        data object AccountNotFound : Failure
     }
 }
 

--- a/src/main/kotlin/pizza/psycho/sos/identity/account/domain/Account.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/domain/Account.kt
@@ -43,4 +43,8 @@ class Account protected constructor() : BaseDeletableEntity() {
                 this.displayName = "$givenName $familyName"
             }
     }
+
+    fun updateDisplayName(displayName: String) {
+        this.displayName = displayName
+    }
 }

--- a/src/main/kotlin/pizza/psycho/sos/identity/account/presentation/AccountController.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/presentation/AccountController.kt
@@ -2,6 +2,8 @@ package pizza.psycho.sos.identity.account.presentation
 
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -14,6 +16,7 @@ import pizza.psycho.sos.identity.account.application.service.dto.AccountCommand
 import pizza.psycho.sos.identity.account.application.service.dto.AccountResult
 import pizza.psycho.sos.identity.account.presentation.dto.AccountRequest
 import pizza.psycho.sos.identity.account.presentation.dto.AccountResponse
+import pizza.psycho.sos.identity.security.principal.AuthenticatedAccountPrincipal
 
 @RestController
 @RequestMapping("/api/v1/accounts")
@@ -32,9 +35,27 @@ class AccountController(
                     firstName = request.firstName,
                     lastName = request.lastName,
                 ),
-            ).toApiResponse()
+            ).toRegisterApiResponse()
 
-    private fun AccountResult.toApiResponse(): ApiResponse<AccountResponse.Register> =
+    @PatchMapping("/me/display-name")
+    fun updateDisplayName(
+        authentication: Authentication,
+        @Valid @RequestBody request: AccountRequest.UpdateDisplayName,
+    ): ApiResponse<AccountResponse.UpdateDisplayName> {
+        val principal =
+            authentication.principal as? AuthenticatedAccountPrincipal
+                ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized")
+
+        return accountService
+            .updateDisplayName(
+                AccountCommand.UpdateDisplayName(
+                    accountId = principal.accountId,
+                    displayName = request.displayName,
+                ),
+            ).toUpdateDisplayNameApiResponse()
+    }
+
+    private fun AccountResult.toRegisterApiResponse(): ApiResponse<AccountResponse.Register> =
         when (this) {
             is AccountResult.Registered ->
                 responseOf(
@@ -51,5 +72,30 @@ class AccountController(
                 HttpStatus.CONFLICT,
                 "Email already registered",
             )
+
+            else -> throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR)
+        }
+
+    private fun AccountResult.toUpdateDisplayNameApiResponse(): ApiResponse<AccountResponse.UpdateDisplayName> =
+        when (this) {
+            is AccountResult.Updated.DisplayName ->
+                responseOf(
+                    data =
+                        AccountResponse.UpdateDisplayName(
+                            displayName = displayName,
+                        ),
+                )
+
+            AccountResult.Failure.InvalidDisplayName -> throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Invalid display name",
+            )
+
+            AccountResult.Failure.AccountNotFound -> throw ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                "Account not found",
+            )
+
+            else -> throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR)
         }
 }

--- a/src/main/kotlin/pizza/psycho/sos/identity/account/presentation/dto/AccountRequest.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/presentation/dto/AccountRequest.kt
@@ -18,6 +18,11 @@ sealed interface AccountRequest {
         val lastName: String,
     )
 
+    data class UpdateDisplayName(
+        @field:NotBlank
+        val displayName: String,
+    )
+
     data class Withdraw(
         // TODO
         val example: Nothing,

--- a/src/main/kotlin/pizza/psycho/sos/identity/account/presentation/dto/AccountResponse.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/presentation/dto/AccountResponse.kt
@@ -8,6 +8,10 @@ sealed interface AccountResponse {
         val lastName: String,
     )
 
+    data class UpdateDisplayName(
+        val displayName: String,
+    )
+
     data class Withdraw(
         // TODO
         val example: Nothing,

--- a/src/main/kotlin/pizza/psycho/sos/identity/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/security/config/SecurityConfig.kt
@@ -34,7 +34,7 @@ class SecurityConfig(
                 it
                     .requestMatchers(
                         "/api/v1/auth/**",
-                        "/api/v1/accounts/**",
+                        "/api/v1/accounts/register",
                         "/actuator/**",
                         "/v3/api-docs/**",
                         "/swagger-ui/**",

--- a/src/test/kotlin/pizza/psycho/sos/identity/account/application/AccountServiceTests.kt
+++ b/src/test/kotlin/pizza/psycho/sos/identity/account/application/AccountServiceTests.kt
@@ -72,4 +72,106 @@ class AccountServiceTests {
         assertEquals("Rick", registered.account.firstName)
         assertEquals("Sanchez", registered.account.lastName)
     }
+
+    @Test
+    fun `update display name trims and updates account`() {
+        val accountId = UUID.fromString("00000000-0000-0000-0000-000000000111")
+        val account =
+            Account
+                .create(
+                    email = "user@psycho.pizza",
+                    passwordHash = "encoded-password",
+                    givenName = "Rick",
+                    familyName = "Sanchez",
+                ).also { it.id = accountId }
+        val command =
+            AccountCommand.UpdateDisplayName(
+                accountId = accountId,
+                displayName = "  Pickle Rick  ",
+            )
+
+        `when`(accountRepository.findByIdAndDeletedAtIsNull(accountId)).thenReturn(account)
+
+        val result = accountService.updateDisplayName(command)
+
+        assertEquals(
+            AccountResult.Updated.DisplayName(
+                displayName = "Pickle Rick",
+            ),
+            result,
+        )
+        assertEquals("Pickle Rick", account.displayName)
+    }
+
+    @Test
+    fun `update display name returns invalid display name failure for blank input`() {
+        val command =
+            AccountCommand.UpdateDisplayName(
+                accountId = UUID.fromString("00000000-0000-0000-0000-000000000111"),
+                displayName = "   ",
+            )
+
+        val result = accountService.updateDisplayName(command)
+
+        assertTrue(result is AccountResult.Failure.InvalidDisplayName)
+    }
+
+    @Test
+    fun `update display name returns account not found failure`() {
+        val accountId = UUID.fromString("00000000-0000-0000-0000-000000000222")
+        val command =
+            AccountCommand.UpdateDisplayName(
+                accountId = accountId,
+                displayName = "Summer",
+            )
+
+        `when`(accountRepository.findByIdAndDeletedAtIsNull(accountId)).thenReturn(null)
+
+        val result = accountService.updateDisplayName(command)
+
+        assertTrue(result is AccountResult.Failure.AccountNotFound)
+    }
+
+    @Test
+    fun `update display name accepts input longer than 40 only when trimmed value is within range`() {
+        val accountId = UUID.fromString("00000000-0000-0000-0000-000000000333")
+        val account =
+            Account
+                .create(
+                    email = "user@psycho.pizza",
+                    passwordHash = "encoded-password",
+                    givenName = "Rick",
+                    familyName = "Sanchez",
+                ).also { it.id = accountId }
+        val validTrimmedDisplayName = "a".repeat(40)
+        val command =
+            AccountCommand.UpdateDisplayName(
+                accountId = accountId,
+                displayName = "  $validTrimmedDisplayName  ",
+            )
+
+        `when`(accountRepository.findByIdAndDeletedAtIsNull(accountId)).thenReturn(account)
+
+        val result = accountService.updateDisplayName(command)
+
+        assertEquals(
+            AccountResult.Updated.DisplayName(
+                displayName = validTrimmedDisplayName,
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `update display name returns invalid display name failure when trimmed length exceeds 40`() {
+        val command =
+            AccountCommand.UpdateDisplayName(
+                accountId = UUID.fromString("00000000-0000-0000-0000-000000000444"),
+                displayName = "a".repeat(41),
+            )
+
+        val result = accountService.updateDisplayName(command)
+
+        assertTrue(result is AccountResult.Failure.InvalidDisplayName)
+    }
 }

--- a/src/test/kotlin/pizza/psycho/sos/identity/account/domain/AccountTests.kt
+++ b/src/test/kotlin/pizza/psycho/sos/identity/account/domain/AccountTests.kt
@@ -34,4 +34,19 @@ class AccountTests {
 
         assertEquals("Rick Sanchez", account.displayName)
     }
+
+    @Test
+    fun `update display name changes display name`() {
+        val account =
+            Account.create(
+                email = "user@psycho.pizza",
+                passwordHash = "encoded-password",
+                givenName = "Rick",
+                familyName = "Sanchez",
+            )
+
+        account.updateDisplayName("Pickle Rick")
+
+        assertEquals("Pickle Rick", account.displayName)
+    }
 }

--- a/src/test/kotlin/pizza/psycho/sos/identity/account/presentation/AccountControllerTests.kt
+++ b/src/test/kotlin/pizza/psycho/sos/identity/account/presentation/AccountControllerTests.kt
@@ -1,0 +1,118 @@
+package pizza.psycho.sos.identity.account.presentation
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import pizza.psycho.sos.identity.account.application.service.AccountService
+import pizza.psycho.sos.identity.account.application.service.dto.AccountCommand
+import pizza.psycho.sos.identity.account.application.service.dto.AccountResult
+import pizza.psycho.sos.identity.security.principal.AuthenticatedAccountPrincipal
+import pizza.psycho.sos.identity.security.token.AccessTokenProvider
+import java.util.UUID
+
+@WebMvcTest(AccountController::class)
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class AccountControllerTests {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var accessTokenProvider: AccessTokenProvider
+
+    @Test
+    fun `update display name returns updated display name from service payload`() {
+        val principal =
+            AuthenticatedAccountPrincipal(
+                accountId = UUID.fromString("00000000-0000-0000-0000-000000000111"),
+                email = "user@psycho.pizza",
+            )
+        val authentication = UsernamePasswordAuthenticationToken(principal, null, emptyList())
+        `when`(
+            accountService.updateDisplayName(
+                AccountCommand.UpdateDisplayName(
+                    accountId = principal.accountId,
+                    displayName = "  Pickle Rick  ",
+                ),
+            ),
+        ).thenReturn(
+            AccountResult.Updated.DisplayName(
+                displayName = "Pickle Rick",
+            ),
+        )
+
+        mockMvc
+            .perform(
+                patch("/api/v1/accounts/me/display-name")
+                    .principal(authentication)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"displayName":"  Pickle Rick  "}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.displayName").value("Pickle Rick"))
+    }
+
+    @Test
+    fun `update display name returns bad request when invalid`() {
+        val principal =
+            AuthenticatedAccountPrincipal(
+                accountId = UUID.fromString("00000000-0000-0000-0000-000000000111"),
+                email = "user@psycho.pizza",
+            )
+        val authentication = UsernamePasswordAuthenticationToken(principal, null, emptyList())
+        `when`(
+            accountService.updateDisplayName(
+                AccountCommand.UpdateDisplayName(
+                    accountId = principal.accountId,
+                    displayName = "invalid",
+                ),
+            ),
+        ).thenReturn(AccountResult.Failure.InvalidDisplayName)
+
+        mockMvc
+            .perform(
+                patch("/api/v1/accounts/me/display-name")
+                    .principal(authentication)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"displayName":"invalid"}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `update display name returns not found when account does not exist`() {
+        val principal =
+            AuthenticatedAccountPrincipal(
+                accountId = UUID.fromString("00000000-0000-0000-0000-000000000111"),
+                email = "user@psycho.pizza",
+            )
+        val authentication = UsernamePasswordAuthenticationToken(principal, null, emptyList())
+        `when`(
+            accountService.updateDisplayName(
+                AccountCommand.UpdateDisplayName(
+                    accountId = principal.accountId,
+                    displayName = "Summer",
+                ),
+            ),
+        ).thenReturn(AccountResult.Failure.AccountNotFound)
+
+        mockMvc
+            .perform(
+                patch("/api/v1/accounts/me/display-name")
+                    .principal(authentication)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"displayName":"Summer"}"""),
+            ).andExpect(status().isNotFound)
+    }
+}

--- a/src/test/kotlin/pizza/psycho/sos/identity/account/presentation/AccountSecurityTests.kt
+++ b/src/test/kotlin/pizza/psycho/sos/identity/account/presentation/AccountSecurityTests.kt
@@ -1,0 +1,87 @@
+package pizza.psycho.sos.identity.account.presentation
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import pizza.psycho.sos.identity.account.application.service.AccountService
+import pizza.psycho.sos.identity.account.application.service.dto.AccountCommand
+import pizza.psycho.sos.identity.account.application.service.dto.AccountResult
+import pizza.psycho.sos.identity.account.application.service.dto.AccountSnapshot
+import pizza.psycho.sos.identity.security.config.SecurityConfig
+import pizza.psycho.sos.identity.security.filter.JwtAuthenticationFilter
+import pizza.psycho.sos.identity.security.token.AccessTokenProvider
+
+@WebMvcTest(AccountController::class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@ActiveProfiles("test")
+class AccountSecurityTests {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var accountService: AccountService
+
+    @MockitoBean
+    private lateinit var accessTokenProvider: AccessTokenProvider
+
+    @Test
+    fun `update display name requires authentication`() {
+        mockMvc
+            .perform(
+                patch("/api/v1/accounts/me/display-name")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"displayName":"Summer"}"""),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `register is accessible without authentication`() {
+        `when`(
+            accountService.register(
+                AccountCommand.Register(
+                    email = "user@psycho.pizza",
+                    password = "Password123!",
+                    firstName = "Rick",
+                    lastName = "Sanchez",
+                ),
+            ),
+        ).thenReturn(
+            AccountResult.Registered(
+                account =
+                    AccountSnapshot(
+                        id = "00000000-0000-0000-0000-000000000111",
+                        email = "user@psycho.pizza",
+                        firstName = "Rick",
+                        lastName = "Sanchez",
+                    ),
+            ),
+        )
+
+        mockMvc
+            .perform(
+                post("/api/v1/accounts/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                          "email":"user@psycho.pizza",
+                          "password":"Password123!",
+                          "firstName":"Rick",
+                          "lastName":"Sanchez"
+                        }
+                        """.trimIndent(),
+                    ),
+            ).andExpect(status().isOk)
+    }
+}


### PR DESCRIPTION
## Summary
<!-- What changed? (1-3 lines) -->
* 회원이 본인 Account의 display name을 직접 변경할 수 있는 API를 추가
* 기존 회원가입 시 자동 생성되던 display name을 수정 가능하도록 확장

## Why
<!-- Why is this needed? -->
* 인증 기반 도메인 변경점을 구현하여 다른 모듈 없이 단독적으로 인증 기능 정상 작동을 테스트하기 위함

## Changes
- `PATCH /api/v1/accounts/me/display-name` 엔드포인트 추가 (JWT 인증 사용자 기준)
- Account 서비스/도메인에 display name 변경 로직 추가 (`trim` 후 `1..40` 길이 검증 포함)
- `AccountResult`에 `Updated.DisplayName(displayName: String)` 결과 타입 및 실패 타입(`InvalidDisplayName`, `AccountNotFound`) 추가
- `SecurityConfig` 수정: `/api/v1/accounts/register`만 `permitAll`, 나머지 accounts API는 인증 필요

- 테스트 추가/보강
  - 도메인 테스트: display name 변경 동작
  - 서비스 테스트: 성공/공백/길이초과/계정미존재 케이스
  - 컨트롤러 테스트: 200/400/404 응답 매핑
  - 보안 테스트: 미인증 요청 401, register 공개 접근 확인

## How to Test
- [x] `./gradlew test`
- [x] Manual check done (if needed)

## Notes
<!-- Optional: screenshots, risks, follow-ups -->
