### PR TITLE
feat: separate workflow to test, build+deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,15 +7,14 @@ on:
     branches: [ main, dev ]
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Set up JDK 21
@@ -26,6 +25,9 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: Check Kotlin formatting
+        run: ./gradlew ktlintCheck
 
       - name: Test
         env:
@@ -45,9 +47,32 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-reports
+          retention-days: 1
           path: |
-            build/test-results/test/**
+            build/test-results/test/*.xml
             build/reports/tests/test/**
+            build/reports/ktlint/**
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
       - name: Build JAR
         run: ./gradlew bootJar
@@ -59,23 +84,6 @@ jobs:
           cp appspec.yml deploy/
           cp -r scripts deploy/
           cd deploy && zip -r ../psycho-pizza-${{ github.sha }}.zip .
-
-      - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: deploy-bundle
-          path: psycho-pizza-${{ github.sha }}.zip
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-
-    steps:
-      - name: Download bundle artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: deploy-bundle
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -50,7 +50,7 @@ echo "  - JAR: $JAR_FILE"
 
 # ── 4. 애플리케이션 실행 ───────────────────
 nohup java -jar \
-  -Dspring.profiles.active=prod \
+  -D spring.profiles.active=prod \
   "${JAR_FILE}" \
   > "${APP_DIR}/app.log" 2>&1 &
 


### PR DESCRIPTION
## Summary
<!-- What changed? (1-3 lines) -->
* 기존의 빌드와 배포로 분리되어있던 워크플로우를 테스트 only와 빌드 및 배포로 조정합니다.

## Why
<!-- Why is this needed? -->
* 빌드와 배포로 쪼갤 경우 빌드 결과물이 필요하지 않은 경우에도 매번 빌드를 수행함
* 배포시 배포를 위한 빌드를 다시 또 생성해야 함
* 결과적으로 빌드 결과물이 불필요하게 많이 쌓임

## Changes
- ci-cd.yml
- deploy.sh

## How to Test
- [ ] `./gradlew test`
- [x] Manual check done (if needed)

## Notes
<!-- Optional: screenshots, risks, follow-ups -->
