### PR TITLE
!chore: SSM parameter now synced with relay server

### DIFF
--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -25,7 +25,7 @@ echo "Loading environment variables from SSM..."
 # .env 파일 생성 (systemd EnvironmentFile 형식: KEY=VALUE)
 cat > ${ENV_FILE} <<EOF
 SPRING_PROFILES_ACTIVE=prod
-SPRING_DATASOURCE_URL=$(get_param db-url)
+SPRING_DATASOURCE_URL=jdbc:postgresql://$(get_param db-host):$(get_param db-port)/$(get_param db-name)
 SPRING_DATASOURCE_USERNAME=$(get_param db-username)
 SPRING_DATASOURCE_PASSWORD=$(get_param db-password)
 JWT_ISSUER=$(get_param jwt-issuer)


### PR DESCRIPTION
## Summary
<!-- What changed? (1-3 lines) -->
* 파이썬 서버에서 DB 접근시 host, port, db name을 별도로 사용함에 따라 SSM parameter 값 변경

## Why
<!-- Why is this needed? -->
* SQL Alchemy가 한 라인으로 된 URL을 받는게 아니라 호스트/포트/데이터베이스를 별도로 받는 포맷이라, 호환성을 위해 변경

## Changes
- after_install.sh

## How to Test
- [ ] `./gradlew test`
- [x] Manual check done (if needed)

## Notes
<!-- Optional: screenshots, risks, follow-ups -->
* .env 파일 로딩으로 모든 환경변수 오버라이딩 방식은 prod ec2 내부에서만 사용
* local, dev 환경에서는 기존과 동일하게 application.yml 기반으로 사용하니 로컬 환경변수는 조정 안 하셔도 됩니다
* 현재 시점으로 SSM 환경변수는 이미 3조각으로 분해됐기에, dev 머지 없이 main 브랜치 단독 재배포 수행시 환경변수 누락으로 인스턴스 크래시 발생 위험!