### PR TITLE
Feat/psy 100/add email template

### DIFF
--- a/src/main/kotlin/pizza/psycho/sos/common/message/channel/mail/send/application/command/MailSendCommand.kt
+++ b/src/main/kotlin/pizza/psycho/sos/common/message/channel/mail/send/application/command/MailSendCommand.kt
@@ -1,5 +1,6 @@
 package pizza.psycho.sos.common.message.channel.mail.send.application.command
 
+import pizza.psycho.sos.common.message.channel.mail.template.domain.data.EmailAlreadyExistsTemplateData
 import pizza.psycho.sos.common.message.channel.mail.template.domain.data.OtpTemplateData
 import pizza.psycho.sos.common.message.channel.mail.template.domain.data.WorkspaceInviteTemplateData
 import pizza.psycho.sos.common.message.domain.MessageType
@@ -22,6 +23,13 @@ sealed interface MailSendCommand {
         val templateData: OtpTemplateData,
     ) : MailSendCommand {
         val mailType: MessageType = MessageType.OTP
+    }
+
+    data class EmailAlreadyExists(
+        override val to: String,
+        val templateData: EmailAlreadyExistsTemplateData,
+    ) : MailSendCommand {
+        val mailType: MessageType = MessageType.EMAIL_ALREADY_EXISTS
     }
 
     data class General(

--- a/src/main/kotlin/pizza/psycho/sos/common/message/channel/mail/send/application/service/MailSendService.kt
+++ b/src/main/kotlin/pizza/psycho/sos/common/message/channel/mail/send/application/service/MailSendService.kt
@@ -9,6 +9,7 @@ import pizza.psycho.sos.common.message.channel.mail.send.application.model.MailS
 import pizza.psycho.sos.common.message.channel.mail.send.application.port.MailSender
 import pizza.psycho.sos.common.message.channel.mail.send.presentation.dto.MailSendStatus
 import pizza.psycho.sos.common.message.channel.mail.template.application.service.MailTemplateService
+import pizza.psycho.sos.common.message.channel.mail.template.domain.data.EmailAlreadyExistsTemplateData
 import pizza.psycho.sos.common.message.channel.mail.template.domain.data.OtpTemplateData
 import pizza.psycho.sos.common.message.channel.mail.template.domain.data.WorkspaceInviteTemplateData
 import pizza.psycho.sos.common.message.domain.MessageChannel
@@ -32,6 +33,7 @@ class MailSendService(
             is MailSendCommand.General -> sendGeneral(command)
             is MailSendCommand.Otp -> sendOtp(command)
             is MailSendCommand.WorkspaceInvite -> sendWorkspaceInvite(command)
+            is MailSendCommand.EmailAlreadyExists -> sendEmailAlreadyExists(command)
         }
 
     fun send(
@@ -182,6 +184,34 @@ class MailSendService(
         return MailSendStatus.SUCCESS
     }
 
+    private fun sendEmailAlreadyExists(command: MailSendCommand.EmailAlreadyExists): MailSendStatus {
+        val normalizedEmail = command.to.trim().lowercase()
+        logger.info("Sending mail. mailType={} to={}", command.mailType, normalizedEmail)
+        val template = mailTemplateService.getActiveTemplate(command.mailType)
+        if (!command.mailType.supportedChannels.contains(MessageChannel.EMAIL)) {
+            throw DomainException(
+                MessageErrorCode.MESSAGE_CHANNEL_NOT_SUPPORTED,
+                "channel EMAIL is not supported for mailType=${command.mailType}",
+            )
+        }
+        if (template.tokenAuthEnabled) {
+            throw DomainException(
+                MessageErrorCode.MESSAGE_TOKEN_AUTH_NOT_SUPPORTED,
+                "token auth is not supported for mailType=${command.mailType}",
+            )
+        }
+
+        val rendered = mailTemplateService.render(command.templateData)
+        mailSender.send(
+            MailSendRequest(
+                to = normalizedEmail,
+                subject = rendered.title,
+                htmlContent = rendered.htmlContent,
+            ),
+        )
+        return MailSendStatus.SUCCESS
+    }
+
     private fun toCommand(
         mailType: MessageType,
         to: String,
@@ -211,6 +241,18 @@ class MailSendService(
                         ),
                     workspaceId = params.requiredUuid("workspaceId"),
                     requesterAccountId = params.requiredUuid("inviterAccountId"),
+                )
+
+            MessageType.EMAIL_ALREADY_EXISTS ->
+                MailSendCommand.EmailAlreadyExists(
+                    to = to,
+                    templateData =
+                        EmailAlreadyExistsTemplateData(
+                            email = params.required("email"),
+                            name = params.required("name"),
+                            joinedAt = params.required("joinedAt"),
+                            url = params.required("url"),
+                        ),
                 )
         }
 

--- a/src/main/kotlin/pizza/psycho/sos/common/message/channel/mail/template/domain/data/EmailAlreadyExistsTemplateData.kt
+++ b/src/main/kotlin/pizza/psycho/sos/common/message/channel/mail/template/domain/data/EmailAlreadyExistsTemplateData.kt
@@ -1,0 +1,20 @@
+package pizza.psycho.sos.common.message.channel.mail.template.domain.data
+
+import pizza.psycho.sos.common.message.domain.MessageType
+
+data class EmailAlreadyExistsTemplateData(
+    val email: String,
+    val name: String,
+    val joinedAt: String,
+    val url: String,
+) : MailTemplateData {
+    override val mailType: MessageType = MessageType.EMAIL_ALREADY_EXISTS
+
+    override fun variables(): Map<String, String?> =
+        mapOf(
+            "email" to email,
+            "name" to name,
+            "joinedAt" to joinedAt,
+            "url" to url,
+        )
+}

--- a/src/main/kotlin/pizza/psycho/sos/common/message/channel/mail/template/domain/spec/MailTemplateSpec.kt
+++ b/src/main/kotlin/pizza/psycho/sos/common/message/channel/mail/template/domain/spec/MailTemplateSpec.kt
@@ -60,6 +60,33 @@ object MailTemplateSpecRegistry {
                             ),
                         ),
                 ),
+            MessageType.EMAIL_ALREADY_EXISTS to
+                MailTemplateSpec(
+                    mailType = MessageType.EMAIL_ALREADY_EXISTS,
+                    variables =
+                        listOf(
+                            MailTemplateVariableSpec(
+                                name = "email",
+                                required = true,
+                                description = "이미 가입된 이메일 주소",
+                            ),
+                            MailTemplateVariableSpec(
+                                name = "name",
+                                required = true,
+                                description = "가입자 이름",
+                            ),
+                            MailTemplateVariableSpec(
+                                name = "joinedAt",
+                                required = true,
+                                description = "가입 일자",
+                            ),
+                            MailTemplateVariableSpec(
+                                name = "url",
+                                required = true,
+                                description = "로그인 페이지 URL",
+                            ),
+                        ),
+                ),
         )
 
     fun get(mailType: MessageType): MailTemplateSpec =

--- a/src/main/kotlin/pizza/psycho/sos/common/message/domain/MessageType.kt
+++ b/src/main/kotlin/pizza/psycho/sos/common/message/domain/MessageType.kt
@@ -5,4 +5,5 @@ enum class MessageType(
 ) {
     OTP(setOf(MessageChannel.EMAIL)),
     WORKSPACE_INVITE(setOf(MessageChannel.EMAIL)),
+    EMAIL_ALREADY_EXISTS(setOf(MessageChannel.EMAIL)),
 }

--- a/src/main/resources/db/migration/V11__seed_email_already_exists_mail_template.sql
+++ b/src/main/resources/db/migration/V11__seed_email_already_exists_mail_template.sql
@@ -1,0 +1,66 @@
+-- flyway:placeholderReplacement=false
+-- EMAIL_ALREADY_EXISTS 템플릿 시드 데이터
+
+insert into mail_templates
+(
+    id,
+    created_at,
+    updated_at,
+    deleted_at,
+    deleted_by,
+    mail_type,
+    title,
+    description,
+    action_type,
+    token_auth_enabled,
+    token_expire_hours,
+    html_content
+)
+select
+    gen_random_uuid(),
+    now(),
+    now(),
+    null,
+    null,
+    'EMAIL_ALREADY_EXISTS',
+    '[psycho] 이미 가입된 이메일 안내',
+    '이미 가입된 이메일 안내 메일',
+    null,
+    false,
+    null,
+    $$<!doctype html>
+<html>
+  <body style="font-family: Arial, sans-serif; background:#f6f7fb; padding:24px;">
+    <div style="max-width:560px;margin:0 auto;background:#ffffff;border-radius:12px;padding:24px;text-align:center;">
+      <h2 style="margin:0 0 12px 0;">이미 가입된 이메일입니다</h2>
+      <p style="margin:0 0 12px 0;">
+        ${name} 님, <strong>${email}</strong> 계정은 이미 가입되어 있습니다.
+      </p>
+      <p style="margin:0 0 12px 0;">
+        가입일자: ${joinedAt}
+      </p>
+      <p style="margin:0 0 20px 0;">
+        아래 버튼을 누르면 로그인 페이지로 이동할 수 있습니다.
+      </p>
+      <div>
+        <a href="${url}"
+           style="display:inline-block;background:#111827;color:#ffffff;text-decoration:none;
+                  padding:12px 18px;border-radius:8px;font-weight:bold;">
+          로그인하러 가기
+        </a>
+      </div>
+      <p style="margin:20px 0 0 0;font-size:12px;color:#6b7280;word-break:break-all;">
+        버튼이 동작하지 않으면 아래 링크를 복사해 주세요.<br/>
+        ${url}
+      </p>
+    </div>
+  </body>
+</html>$$
+where not exists (
+    select 1
+    from mail_templates
+    where
+        mail_type = 'EMAIL_ALREADY_EXISTS'
+        and deleted_at is null
+);
+

--- a/src/test/kotlin/pizza/psycho/sos/common/mail/send/application/service/MailSendServiceTests.kt
+++ b/src/test/kotlin/pizza/psycho/sos/common/mail/send/application/service/MailSendServiceTests.kt
@@ -13,6 +13,7 @@ import pizza.psycho.sos.common.message.channel.mail.send.application.model.MailS
 import pizza.psycho.sos.common.message.channel.mail.send.application.port.MailSender
 import pizza.psycho.sos.common.message.channel.mail.send.presentation.dto.MailSendStatus
 import pizza.psycho.sos.common.message.channel.mail.template.application.service.MailTemplateService
+import pizza.psycho.sos.common.message.channel.mail.template.domain.data.EmailAlreadyExistsTemplateData
 import pizza.psycho.sos.common.message.channel.mail.template.domain.data.MailTemplateData
 import pizza.psycho.sos.common.message.channel.mail.template.domain.data.OtpTemplateData
 import pizza.psycho.sos.common.message.channel.mail.template.domain.data.WorkspaceInviteTemplateData
@@ -179,6 +180,68 @@ class MailSendServiceTests {
         assertEquals("user@psycho.pizza", requestSlot.captured.to)
         assertEquals("초대합니다", requestSlot.captured.subject)
         assertEquals("<p>hello</p>", requestSlot.captured.htmlContent)
+        verify(exactly = 1) { mailTemplateService.render(any()) }
+        verify(exactly = 1) { mailSender.send(any()) }
+        verify(exactly = 0) {
+            mailAuthTokenService.issue(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `이미 가입된 이메일 안내 메일은 템플릿을 렌더링해 로그인 링크와 함께 발송한다`() {
+        val template =
+            MailTemplate(
+                mailType = MessageType.EMAIL_ALREADY_EXISTS,
+                title = "[psycho] 이미 가입된 이메일 안내",
+                description = "email exists",
+                actionType = null,
+                tokenAuthEnabled = false,
+                tokenExpireHours = null,
+                htmlContent = "<a href=\"\${url}\">login</a>",
+            )
+        val rendered =
+            RenderedMailTemplate(
+                title = "이미 가입된 이메일입니다",
+                htmlContent = "<a href=\"https://psycho.pizza/login\">login</a>",
+            )
+
+        every { mailTemplateService.getActiveTemplate(MessageType.EMAIL_ALREADY_EXISTS) } returns template
+        val dataSlot = slot<MailTemplateData>()
+        every { mailTemplateService.render(capture(dataSlot)) } returns rendered
+        val requestSlot = slot<MailSendRequest>()
+        every { mailSender.send(capture(requestSlot)) } returns Unit
+
+        val status =
+            mailSendService.send(
+                mailType = MessageType.EMAIL_ALREADY_EXISTS,
+                to = "USER@PSYCHO.PIZZA",
+                params =
+                    mapOf(
+                        "email" to "existing@psycho.pizza",
+                        "name" to "Kim",
+                        "joinedAt" to "2026-03-01",
+                        "url" to "https://psycho.pizza/login",
+                    ),
+            )
+
+        assertEquals(MailSendStatus.SUCCESS, status)
+        val capturedData = dataSlot.captured as EmailAlreadyExistsTemplateData
+        assertEquals("existing@psycho.pizza", capturedData.email)
+        assertEquals("Kim", capturedData.name)
+        assertEquals("2026-03-01", capturedData.joinedAt)
+        assertEquals("https://psycho.pizza/login", capturedData.url)
+        assertEquals("user@psycho.pizza", requestSlot.captured.to)
+        assertEquals("이미 가입된 이메일입니다", requestSlot.captured.subject)
+        assertEquals("<a href=\"https://psycho.pizza/login\">login</a>", requestSlot.captured.htmlContent)
+        verify(exactly = 1) { mailTemplateService.getActiveTemplate(MessageType.EMAIL_ALREADY_EXISTS) }
         verify(exactly = 1) { mailTemplateService.render(any()) }
         verify(exactly = 1) { mailSender.send(any()) }
         verify(exactly = 0) {


### PR DESCRIPTION
## Summary
<!-- What changed? (1-3 lines) -->
Add an `EMAIL_ALREADY_EXISTS` mail template

## Why
<!-- Why is this needed? -->
  We need a dedicated email template to inform users that the email is already registered and guide them back to the login page.


## Changes
- add mail template 

## How to Test
- [x] `./gradlew test`
- [x] Manual check done (if needed)

## Notes
<!-- Optional: screenshots, risks, follow-ups -->
<img width="1112" height="463" alt="image" src="https://github.com/user-attachments/assets/3726a5b3-ccf4-4dcb-a8f7-ab6ce745ecbc" />

@rchrdcho  
