### PR TITLE
fix: findActiveDisplayNameByAccountIdOrNull now throws exception

### DIFF
--- a/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/AccountService.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/AccountService.kt
@@ -4,10 +4,12 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import pizza.psycho.sos.common.domain.vo.Email
+import pizza.psycho.sos.common.handler.DomainException
 import pizza.psycho.sos.common.support.transaction.helper.Tx
 import pizza.psycho.sos.common.support.transaction.helper.hasConstraintName
 import pizza.psycho.sos.identity.account.application.service.dto.AccountCommand
 import pizza.psycho.sos.identity.account.domain.Account
+import pizza.psycho.sos.identity.account.domain.exception.AccountErrorCode
 import pizza.psycho.sos.identity.account.infrastructure.AccountRepository
 import pizza.psycho.sos.identity.authentication.application.service.RefreshTokenService
 import pizza.psycho.sos.identity.challenge.application.service.ChallengeService
@@ -32,10 +34,17 @@ class AccountService(
             .findByEmailValueIgnoreCaseAndDeletedAtIsNull(Email.of(email).value)
             ?.id
 
-    fun findActiveDisplayNameByAccountIdOrNull(accountId: UUID): String? =
-        accountRepository
-            .findByIdAndDeletedAtIsNull(accountId)
-            ?.let { "${it.givenName} ${it.familyName}" }
+    /**
+     * [WARNING]
+     * * THIS METHOD ACTUALLY THROWS `DomainException(ACCOUNT_NOT_FOUND)` IN CASE THE RESULT IS NULL
+     */
+    fun findActiveDisplayNameByAccountIdOrNull(accountId: UUID): String {
+        val account =
+            accountRepository.findByIdAndDeletedAtIsNull(accountId)
+                ?: throw DomainException(AccountErrorCode.ACCOUNT_NOT_FOUND)
+
+        return account.let { "${it.givenName} ${it.familyName}" }
+    }
 
     fun register(command: AccountCommand.Register): Register =
         try {

--- a/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/AccountService.kt
+++ b/src/main/kotlin/pizza/psycho/sos/identity/account/application/service/AccountService.kt
@@ -34,11 +34,7 @@ class AccountService(
             .findByEmailValueIgnoreCaseAndDeletedAtIsNull(Email.of(email).value)
             ?.id
 
-    /**
-     * [WARNING]
-     * * THIS METHOD ACTUALLY THROWS `DomainException(ACCOUNT_NOT_FOUND)` IN CASE THE RESULT IS NULL
-     */
-    fun findActiveDisplayNameByAccountIdOrNull(accountId: UUID): String {
+    fun findActiveDisplayNameByAccountId(accountId: UUID): String {
         val account =
             accountRepository.findByIdAndDeletedAtIsNull(accountId)
                 ?: throw DomainException(AccountErrorCode.ACCOUNT_NOT_FOUND)

--- a/src/main/kotlin/pizza/psycho/sos/workspace/application/port/out/AccountDisplayNamePort.kt
+++ b/src/main/kotlin/pizza/psycho/sos/workspace/application/port/out/AccountDisplayNamePort.kt
@@ -3,5 +3,5 @@ package pizza.psycho.sos.workspace.application.port.out
 import java.util.UUID
 
 interface AccountDisplayNamePort {
-    fun findActiveDisplayNameByAccountIdOrNull(accountId: UUID): String
+    fun findActiveDisplayNameByAccountId(accountId: UUID): String
 }

--- a/src/main/kotlin/pizza/psycho/sos/workspace/application/service/WorkspaceService.kt
+++ b/src/main/kotlin/pizza/psycho/sos/workspace/application/service/WorkspaceService.kt
@@ -287,7 +287,7 @@ class WorkspaceService(
                 throw DomainException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND)
             }
 
-    private fun resolveDisplayName(accountId: UUID): String = accountDisplayNamePort.findActiveDisplayNameByAccountIdOrNull(accountId)
+    private fun resolveDisplayName(accountId: UUID): String = accountDisplayNamePort.findActiveDisplayNameByAccountId(accountId)
 
     companion object {
         private val logger = LoggerFactory.getLogger(WorkspaceService::class.java)

--- a/src/main/kotlin/pizza/psycho/sos/workspace/infrastructure/adapter/AccountDisplayNameAdapter.kt
+++ b/src/main/kotlin/pizza/psycho/sos/workspace/infrastructure/adapter/AccountDisplayNameAdapter.kt
@@ -1,14 +1,13 @@
 package pizza.psycho.sos.workspace.infrastructure.adapter
 
 import org.springframework.stereotype.Component
-import pizza.psycho.sos.identity.account.infrastructure.AccountRepository
+import pizza.psycho.sos.identity.account.application.service.AccountService
 import pizza.psycho.sos.workspace.application.port.out.AccountDisplayNamePort
 import java.util.UUID
 
 @Component
 class AccountDisplayNameAdapter(
-    private val accountRepository: AccountRepository,
+    private val accountService: AccountService,
 ) : AccountDisplayNamePort {
-    override fun findActiveDisplayNameByAccountIdOrNull(accountId: UUID): String =
-        accountRepository.findByIdAndDeletedAtIsNull(accountId)?.let { "${it.givenName} ${it.familyName}".trim() } ?: ""
+    override fun findActiveDisplayNameByAccountId(accountId: UUID): String = accountService.findActiveDisplayNameByAccountId(accountId)
 }

--- a/src/test/kotlin/pizza/psycho/sos/identity/account/application/AccountServiceTests.kt
+++ b/src/test/kotlin/pizza/psycho/sos/identity/account/application/AccountServiceTests.kt
@@ -75,7 +75,7 @@ class AccountServiceTests {
 
         `when`(accountRepository.findByIdAndDeletedAtIsNull(accountId)).thenReturn(account)
 
-        val displayName = accountService.findActiveDisplayNameByAccountIdOrNull(accountId)
+        val displayName = accountService.findActiveDisplayNameByAccountId(accountId)
 
         assertEquals("Rick Sanchez", displayName)
     }
@@ -88,7 +88,7 @@ class AccountServiceTests {
 
         val exception =
             assertFailsWith<DomainException> {
-                accountService.findActiveDisplayNameByAccountIdOrNull(accountId)
+                accountService.findActiveDisplayNameByAccountId(accountId)
             }
 
         assertEquals(AccountErrorCode.ACCOUNT_NOT_FOUND, exception.errorCode)

--- a/src/test/kotlin/pizza/psycho/sos/identity/account/application/AccountServiceTests.kt
+++ b/src/test/kotlin/pizza/psycho/sos/identity/account/application/AccountServiceTests.kt
@@ -2,7 +2,6 @@ package pizza.psycho.sos.identity.account.application
 
 import org.hibernate.exception.ConstraintViolationException
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -16,12 +15,14 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.context.ActiveProfiles
 import pizza.psycho.sos.common.domain.vo.Email
+import pizza.psycho.sos.common.handler.DomainException
 import pizza.psycho.sos.common.support.transaction.helper.Tx
 import pizza.psycho.sos.common.support.transaction.runner.TransactionRunner
 import pizza.psycho.sos.identity.account.application.service.AccountService
 import pizza.psycho.sos.identity.account.application.service.WorkspaceOwnershipQueryService
 import pizza.psycho.sos.identity.account.application.service.dto.AccountCommand
 import pizza.psycho.sos.identity.account.domain.Account
+import pizza.psycho.sos.identity.account.domain.exception.AccountErrorCode
 import pizza.psycho.sos.identity.account.infrastructure.AccountRepository
 import pizza.psycho.sos.identity.authentication.application.service.RefreshTokenService
 import pizza.psycho.sos.identity.challenge.application.service.ChallengeService
@@ -31,6 +32,7 @@ import pizza.psycho.sos.identity.challenge.domain.ConfirmationToken
 import pizza.psycho.sos.identity.challenge.domain.vo.OperationType
 import java.time.Instant
 import java.util.UUID
+import kotlin.test.assertFailsWith
 import pizza.psycho.sos.identity.account.application.service.dto.RegisterAccountResult as Register
 import pizza.psycho.sos.identity.account.application.service.dto.UpdateNameAccountResult as UpdateName
 import pizza.psycho.sos.identity.account.application.service.dto.UpdatePasswordAccountResult as UpdatePassword
@@ -79,14 +81,17 @@ class AccountServiceTests {
     }
 
     @Test
-    fun `find active display name by account id returns null when account is not active`() {
+    fun `find active display name by account id throws account not found when account is not active`() {
         val accountId = UUID.fromString("00000000-0000-0000-0000-000000000011")
 
         `when`(accountRepository.findByIdAndDeletedAtIsNull(accountId)).thenReturn(null)
 
-        val displayName = accountService.findActiveDisplayNameByAccountIdOrNull(accountId)
+        val exception =
+            assertFailsWith<DomainException> {
+                accountService.findActiveDisplayNameByAccountIdOrNull(accountId)
+            }
 
-        assertNull(displayName)
+        assertEquals(AccountErrorCode.ACCOUNT_NOT_FOUND, exception.errorCode)
     }
 
     @Test

--- a/src/test/kotlin/pizza/psycho/sos/workspace/application/WorkspaceServiceTests.kt
+++ b/src/test/kotlin/pizza/psycho/sos/workspace/application/WorkspaceServiceTests.kt
@@ -32,7 +32,7 @@ class WorkspaceServiceTests {
     fun `createWorkspace - creates and saves workspace`() {
         val ownerAccountId = UUID.randomUUID()
         Mockito
-            .`when`(accountDisplayNamePort.findActiveDisplayNameByAccountIdOrNull(ownerAccountId))
+            .`when`(accountDisplayNamePort.findActiveDisplayNameByAccountId(ownerAccountId))
             .thenReturn("Owner Name")
 
         val workspace = service.createWorkspace("Test", "Desc", ownerAccountId)
@@ -115,7 +115,7 @@ class WorkspaceServiceTests {
                 workspaceMembershipQueryRepository.findRoleByWorkspaceIdAndAccountId(workspaceId, ownerAccountId),
             ).thenReturn(Role.OWNER)
         Mockito
-            .`when`(accountDisplayNamePort.findActiveDisplayNameByAccountIdOrNull(crewAccountId))
+            .`when`(accountDisplayNamePort.findActiveDisplayNameByAccountId(crewAccountId))
             .thenReturn("Crew Member")
 
         val membership = service.addMember(workspaceId, ownerAccountId, crewAccountId, Role.CREW)


### PR DESCRIPTION
## Summary
<!-- What changed? (1-3 lines) -->
* `findActiveDisplayNameByAccountIdOrNull` 이 유효한 Account를 찾지 못할 경우 null을 반환하는 대신 exception을 발생시키며 중단됨